### PR TITLE
Also print key when logging environment variables

### DIFF
--- a/lib/env.js
+++ b/lib/env.js
@@ -26,7 +26,7 @@ module.exports = {
         log.error(err.message);
       }
       for (var x in data.message) {
-        log.info('x=', data.message[x]);
+        log.info(x, '=', data.message[x]);
       }
     });
   },


### PR DESCRIPTION
When printing the environment variables for an application the nodester env command always write "x= a value". Printing out "variable name = a value" is probably more useful.
