### PR TITLE
Make `process.env['app_port']` the standard. Because of https://github.c...

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -239,7 +239,7 @@ module.exports = {
         log.info('writing app files');
         fs.writeFileSync(folder + '/.gitignore', rcfile + "\n");
 
-        var defaultCode = "var http = require('http');\n" + "http.createServer(function (req, res) {\n" + "  res.writeHead(200, {'Content-Type': 'text/plain'});\n" + "  res.end('Hello World\\nApp (" + appname + ") is running on Node.JS ' + process.version);\n" + "}).listen(" + data.port + ");\n";
+        var defaultCode = "var http = require('http');\n" + "http.createServer(function (req, res) {\n" + "  res.writeHead(200, {'Content-Type': 'text/plain'});\n" + "  res.end('Hello World\\nApp (" + appname + ") is running on Node.JS ' + process.version);\n" + "}).listen(process.env['app_port'] || 3000);\n";
         var packageJSON= '{\n  "name":"' + appname + '",\n  "node":"0.6.12",\n  "author":"' + config.username + '"\n}';
         fs.writeFileSync(folder + '/' + data.start, defaultCode);
         log.info('writing the package.json file');


### PR DESCRIPTION
...om/nodester/nodester/issues/363
