### PR TITLE
Three little fixes

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -1,41 +1,34 @@
 var log = require('./log');
-    brand = "nodester",
-    apihost = "api.nodester.com",
-    apisecure = false,
     env = process.env,
     fs = require('fs');
-    
-
+    cfg = process.nodester || (process.nodester = {})
 
 process.argv = process.argv.slice(2);
 
 if (env.NODESTER_APIHOST) {
-    apihost = env.NODESTER_APIHOST;
+    cfg.apihost = env.NODESTER_APIHOST;
 }
 if (env.NODESTER_APISECURE) {
-    apisecure = true;
+    cfg.apisecure = true;
 }
 if (env.NODESTER_BRAND) {
-    brand = env.NODESTER_BRAND;
+    cfg.brand = env.NODESTER_BRAND;
 }
 
 
-var nodester_config = {
-    apisecure: apisecure,
-    apihost: apihost,
-    brand: brand,
+var defaults = {
+    apisecure: false,
+    apihost: "api.nodester.com",
+    brand: "nodester",
     appname: '',
     config: {
         username: '',
         password: ''
     }
 };
-if (!process.nodester) {
-    process.nodester = {};
-}
-for (var i in nodester_config) {
-    if (!process.nodester[i]) {
-        process.nodester[i] = nodester_config[i];
+for (var i in defaults) {
+    if (!cfg[i]) {
+        cfg[i] = defaults[i];
     }
 }
 
@@ -89,8 +82,8 @@ exports.run = function(cmds, command) {
       showHelp(exports.commands);
       process.exit(1);
     }
-    
-    if (!cmds[command] && process.nodester.appname) {
+
+    if (!cmds[command] && cfg.appname) {
         command = 'app';
         process.argv.unshift('app');
     }
@@ -122,7 +115,7 @@ var showHelp = exports.showHelp = function(args) {
                 log.usage(i);
             }
         }
-        log.info('For more help, type', brand, 'help <command>');
+        log.info('For more help, type', cfg.brand, 'help <command>');
     }
 }
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -49,8 +49,8 @@ exports.writeApp = function(appname, folder) {
     if (!folder) {
         folder = '';
     }
-    if(!exists(folder)){
-	fs.mkdirSync(folder, '0777');
+    else if(!exists(folder)) {
+        fs.mkdirSync(folder, '0777');
     }
     var config_file = path.join("./" + folder, "." + process.nodester.brand + ".appconfig");
     log.info('Writing app data to config in ' + config_file);


### PR DESCRIPTION
- Nodester now honors the `NODESTER_XXX` env vars even if `process.nodester` is set.
- The  usage hint `For more help, type <brand> help` now displays the correct brand.
- `nodester app setup` no longer throws `ENOENT, no such file or directory ''`
