### PR TITLE
Fix for node 0.10.x.

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -65,7 +65,7 @@ var decryptAuth = function(str) {
   var auth ;
   if (crypto.Decipher) {
     var key = getKey()
-      , c = (new crypto.Decipher()).init("aes192", key);
+      , c = crypto.createDecipher("aes192", key);
     auth = c.update(str, "hex", "utf8");
 
     auth += c.final("utf8");
@@ -82,7 +82,7 @@ var cryptAuth = function(str) {
   var Crypt;
   if (crypto.Cipher) {
     var key = getKey(true);
-    var c = (new crypto.Cipher()).init("aes192", key);
+    var c = crypto.createCipher("aes192", key);
     Crypt = c.update(str, "utf8", "hex");
     Crypt += c.final("hex");
   } else {
@@ -161,7 +161,7 @@ exports.parse = function() {
   var config_file = path.join(process.env.HOME, "." + process.nodester.brand + '.rc');
   if (exists(config_file)) {
     config = iniparser.parseSync(config_file);
-    
+
     var a = decryptAuth(config.auth).split(':');
     process.nodester.config.username = a[0];
     process.nodester.config.password = a[1];


### PR DESCRIPTION
nodester-cli doesn't work with node 0.10.x.

crypto interface changed.

I tested the changes with node 0.10.3.
I verified the new interface is compatible with 0.8.x.

Regards,
Alberto
